### PR TITLE
Added new tests for part1 and part2

### DIFF
--- a/part1.yaml
+++ b/part1.yaml
@@ -1,0 +1,45 @@
+- init:
+    run: rm -f part1 part1.o part1.hi
+    visible: false
+- compile:
+    run: ghc part1.hs -o part1
+    blocker: true
+- case_1:
+    run: ./part1
+    script:
+      - send: "sundays1 1901 1901"
+      - expect: "2"
+      - expect: _EOF_
+- case_2:
+    run: ./part1
+    script:
+      - send: "sundays1tr 1901 1901"
+      - expect: "2"
+      - expect: _EOF_
+- case_3:
+    run: ./part1
+    script:
+      - send: "sundays2 1901 1901"
+      - expect: "2"
+      - expect: _EOF_
+- case_4:
+    run: ./part1
+    script:
+      - send: "sundays1 2000 1901"
+      - expect: "0"
+      - expect: _EOF_
+- case_5:
+    run: ./part1
+    script:
+      - send: "sundays1tr 2000 1901"
+      - expect: "0"
+      - expect: _EOF_
+- case_6:
+    run: ./part1
+    script:
+      - send: "sundays2 2000 1901"
+      - expect: "0"
+      - expect: _EOF_
+- cleanup:
+    run: rm -f part1 part1.o part1.hi
+    visible: false

--- a/part2.yaml
+++ b/part2.yaml
@@ -33,6 +33,21 @@
       - expect: "part2: suit is unknown"
       - expect: _EOF_
     exit: 1
+- case_3:
+    run: ./part2
+    script:
+      - expect: "Enter cards:"
+      - send: "hq"
+      - send: "hj"
+      - send: "."
+      - expect: "Enter moves:"
+      - send: "d"
+      - send: "d"
+      - send: "."
+      - expect: "Enter goal:"
+      - send: "21"
+      - expect: "Score: 0"
+      - expect: _EOF_
 - cleanup:
     run: rm -f part2 part2.o part2.hi
     visible: false

--- a/part2.yaml
+++ b/part2.yaml
@@ -1,0 +1,38 @@
+- init:
+    run: rm -f part2 part2.o part2.hi
+    visible: false
+- compile:
+    run: ghc part2.hs -o part2
+    blocker: true
+- case_1:
+    run: ./part2
+    script:
+      - expect: "Enter cards:"
+      - send: "db"
+      - send: "c2"
+      - send: "."
+      - expect: "Enter moves:"
+      - send: "d"
+      - send: "."
+      - expect: "Enter goal:"
+      - send: "40"
+      - expect: "part2: rank is unknown"
+      - expect: _EOF_
+    exit: 1
+- case_2:
+    run: ./part2
+    script:
+      - expect: "Enter cards:"
+      - send: "z1"
+      - send: "."
+      - expect: "Enter moves:"
+      - send: "d"
+      - send: "."
+      - expect: "Enter goal:"
+      - send: "40"
+      - expect: "part2: suit is unknown"
+      - expect: _EOF_
+    exit: 1
+- cleanup:
+    run: rm -f part2 part2.o part2.hi
+    visible: false

--- a/part2.yaml
+++ b/part2.yaml
@@ -4,7 +4,7 @@
 - compile:
     run: ghc part2.hs -o part2
     blocker: true
-- case_1:
+- case_150150041_1:
     run: ./part2
     script:
       - expect: "Enter cards:"
@@ -19,7 +19,7 @@
       - expect: "part2: rank is unknown"
       - expect: _EOF_
     exit: 1
-- case_2:
+- case_150150041_2:
     run: ./part2
     script:
       - expect: "Enter cards:"
@@ -33,7 +33,7 @@
       - expect: "part2: suit is unknown"
       - expect: _EOF_
     exit: 1
-- case_3:
+- case_150150041_3:
     run: ./part2
     script:
       - expect: "Enter cards:"
@@ -48,7 +48,7 @@
       - send: "21"
       - expect: "Score: 0"
       - expect: _EOF_
-- case_4:
+- case_150150041_4:
     run: ./part2
     script:
       - expect: "Enter cards:"
@@ -63,7 +63,7 @@
       - send: "21"
       - expect: "Score: 0"
       - expect: _EOF_
-- case_5:
+- case_150150041_5:
     run: ./part2
     script:
       - expect: "Enter cards:"

--- a/part2.yaml
+++ b/part2.yaml
@@ -48,6 +48,36 @@
       - send: "21"
       - expect: "Score: 0"
       - expect: _EOF_
+- case_4:
+    run: ./part2
+    script:
+      - expect: "Enter cards:"
+      - send: "h1"
+      - send: "hj"
+      - send: "."
+      - expect: "Enter moves:"
+      - send: "d"
+      - send: "d"
+      - send: "."
+      - expect: "Enter goal:"
+      - send: "21"
+      - expect: "Score: 0"
+      - expect: _EOF_
+- case_5:
+    run: ./part2
+    script:
+      - expect: "Enter cards:"
+      - send: "d1"
+      - send: "hj"
+      - send: "."
+      - expect: "Enter moves:"
+      - send: "d"
+      - send: "d"
+      - send: "."
+      - expect: "Enter goal:"
+      - send: "21"
+      - expect: "Score: 0"
+      - expect: _EOF_
 - cleanup:
     run: rm -f part2 part2.o part2.hi
     visible: false


### PR DESCRIPTION
I added boundary tests for part 1 that are testing the same year and the condition of start year > end year.
For the second part, I added 5 new test cases, 2 of them are testing the error of suit and rank conversion of the card.
The other 3 are testing the getting 0 scores by different kinds of plays. (E.g. drawing the same color with 1 preliminary score).

* While testing `suit is unknown` error by drawing only one card, I found a bug in my code. According to implementation, that test might catch a bug.