### PR TITLE
case names and values are fixed

### DIFF
--- a/part2.yaml
+++ b/part2.yaml
@@ -372,7 +372,7 @@
       - send: "."
       - expect: "Enter goal:"
       - send: "70"
-      - expect: "Score: 38"
+      - expect: "Score: 41"
       - expect: _EOF_
 - case_150150133_3:
     run: ./part2
@@ -482,7 +482,7 @@
       - expect: "part2: card not in list"
       - expect: _EOF_
     exit: 1
-- case_150150133_6:
+- case_150150133_7:
     run: ./part2
     script:
       - expect: "Enter cards:"
@@ -509,9 +509,9 @@
       - send: "."
       - expect: "Enter goal:"
       - send: "70"
-      - expect: "Score: 30"
+      - expect: "Score: 35"
       - expect: _EOF_
-- case_150150133_7:
+- case_150150133_8:
     run: ./part2
     script:
       - expect: "Enter cards:"
@@ -540,7 +540,7 @@
       - send: "20"
       - expect: "Score: 3"
       - expect: _EOF_
-- case_150150133_8:
+- case_150150133_9:
     run: ./part2
     script:
       - expect: "Enter cards:"
@@ -566,7 +566,7 @@
       - send: "."
       - expect: "Enter goal:"
       - send: "70"
-      - expect: "Score: 51"
+      - expect: "Score: 30"
       - expect: _EOF_
 - case_150170710_0:
     run: ./part2


### PR DESCRIPTION
- Case names are fixed due to duplicate case name(case_150150133_6)
- In case_150150133_2, case_150150133_7, and case_150150133_9 (previously case_150150133_2, case_150150133_6 (the one with expected score = 30), and case_150150133_9), expected scores are fixed according to rule "If the player draws and the card-list is empty, the game is over.".